### PR TITLE
Read config from home dir

### DIFF
--- a/bin/jira
+++ b/bin/jira
@@ -17,8 +17,6 @@ rescue Faraday::Error, UnauthorizedException
     end
   end
   puts "JIRA failed connect, you may need to rerun 'jira install'"
-rescue GitException
-  puts "JIRA commands can only be run within a git repository."
 rescue InstallationException
   puts "Please run #{Jira::Format.summary('jira install')} before "\
        "running this command."

--- a/jira-cli.gemspec
+++ b/jira-cli.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Darren Cheng']
   s.email       = 'darren@thanx.com'
-  s.homepage    = 'https://github.com/drn/jira-cli'
+  s.homepage    = 'https://github.com/ruby-jira/jira-cli'
   s.summary     = 'JIRA CLI'
   s.description = 'Ruby CLI managing git-based JIRA workflows'
   s.license     = 'MIT'

--- a/lib/jira/core.rb
+++ b/lib/jira/core.rb
@@ -69,30 +69,20 @@ module Jira
       # @return [String] path to .jira-cli file
       #
       def cli_path
-        @cli_path ||= root_path + "/.jira-cli"
+        @cli_path ||= "#{Dir.home}/.jira-cli"
       end
 
       #
       # @return [String] path to .jira-rescue-cookie file
       #
       def rescue_cookie_path
-        @rescue_cookie_path ||= root_path + "/.jira-rescue-cookie"
+        @rescue_cookie_path ||= "#{Dir.home}/.jira-rescue-cookie"
       end
 
       def config
         @config ||= (
           raise InstallationException unless File.exist?(cli_path)
           IniFile.load(cli_path, comment: '#', encoding: 'UTF-8')
-        )
-      end
-
-    private
-
-      def root_path
-        @root_path ||= (
-          root_path = `git rev-parse --show-toplevel 2>/dev/null`.strip
-          raise GitException if root_path.empty?
-          root_path
         )
       end
 

--- a/lib/jira/exceptions.rb
+++ b/lib/jira/exceptions.rb
@@ -1,3 +1,2 @@
 class InstallationException < StandardError; end
-class GitException < StandardError; end
 class UnauthorizedException < StandardError; end


### PR DESCRIPTION
See: https://github.com/ruby-jira/jira-cli/issues/39

Unfortunately, this change does mean other commands (e.g. `jira all`) will now fail less gracefully if run outside of a `git` repository.
However, the plan is to soon remove these git-specific commands from the gem anyway.